### PR TITLE
Handle deprecated SafeConfigParser() in python 3

### DIFF
--- a/wwpdb/utils/config/ConfigInfoShellExec.py
+++ b/wwpdb/utils/config/ConfigInfoShellExec.py
@@ -180,7 +180,11 @@ class ConfigInfoShellExec(object):
         """
         retD = {}
         try:
-            config = ConfigParser.SafeConfigParser()
+            if sys.version_info[0] > 2:
+                # Python 3.2 deprecates SafeConfigParser()
+                config = ConfigParser.ConfigParser()
+            else:
+                config = ConfigParser.SafeConfigParser()
             # print configFilePath
             config.read(configFilePath)
             sectionL = config.sections()


### PR DESCRIPTION
In python 3, SafeConfigParser() has been deprecated.  One had been fixed, but one was missing.