### PR TITLE
DAOTHER-8060 Add support for ConfigInfoAppCommunication

### DIFF
--- a/wwpdb/utils/config/ConfigInfoApp.py
+++ b/wwpdb/utils/config/ConfigInfoApp.py
@@ -536,3 +536,24 @@ class ConfigInfoAppValidation(ConfigInfoAppBase):
 
     def get_density_fitness(self):
         return os.path.join(self.get_site_packages_path(), "density_fitness", "bin", "density-fitness")
+
+
+class ConfigInfoAppCommunication(ConfigInfoAppBase):
+    """Access configuration for sending email"""
+    def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+        super(ConfigInfoAppCommunication, self).__init__(siteId=siteId, verbose=verbose, log=log)
+
+    def get_noreply_address(self):
+        """Returns the noreply email address"""
+        
+        noreply_email = self._cI.get("SITE_NOREPLY_EMAIL",
+                                     "noreply@mail.wwpdb.org")
+
+        return noreply_email
+
+    def get_mailserver_address(self):
+        """Returns the sendmail local server or relay host"""
+        
+        return self._cI.get("SITE_MAILSERVER", "localhost")
+
+    

--- a/wwpdb/utils/tests-config/ConfigInfoAppCommunicationTests.py
+++ b/wwpdb/utils/tests-config/ConfigInfoAppCommunicationTests.py
@@ -1,0 +1,113 @@
+#
+#
+# File:    ConfigInfoAppCommunicationTests.py
+# Author:  E. Peisach
+# Date:    18-Oct-2020
+# Version: 0.001
+##
+"""
+Test cases for communication settings
+"""
+
+__docformat__ = "restructuredtext en"
+__author__ = "Ezra Peisach"
+__email__ = "peisach@rcsb.rutgers.edu"
+__license__ = "Creative Commons Attribution 3.0 Unported"
+__version__ = "V0.01"
+
+import os
+import platform
+import unittest
+import warnings
+import sys
+
+try:
+    from unittest.mock import patch
+except ImportError:  # pragma: no cover
+    from mock import patch
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+TOPDIR = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+TESTOUTPUT = os.path.join(HERE, "test-output", platform.python_version())
+if not os.path.exists(TESTOUTPUT):  # pragma: no cover
+    os.makedirs(TESTOUTPUT)
+mockTopPath = os.path.join(TOPDIR, "wwpdb", "mock-data")
+rwMockTopPath = os.path.join(TESTOUTPUT)
+
+# Must create config file before importing ConfigInfo
+from wwpdb.utils.testing.SiteConfigSetup import SiteConfigSetup  # noqa: E402
+from wwpdb.utils.testing.CreateRWTree import CreateRWTree  # noqa: E402
+
+# Copy site-config and selected items
+crw = CreateRWTree(mockTopPath, TESTOUTPUT)
+crw.createtree(["site-config", "depuiresources", "webapps"])
+# Use populate r/w site-config using top mock site-config
+SiteConfigSetup().setupEnvironment(rwMockTopPath, rwMockTopPath)
+
+from wwpdb.utils.config.ConfigInfoApp import ConfigInfoAppCommunication  # noqa: E402
+from wwpdb.utils.config.ConfigInfo import ConfigInfo  # noqa: E402
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+TOPDIR = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+
+
+class MyConfigInfo(ConfigInfo):
+    """A class to setup tests for DepUI config"""
+    def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+        self._noreply = "noreply@mail.wwpdb.org"
+        self._server = "localhost"
+        super(MyConfigInfo, self).__init__(siteId=siteId, verbose=verbose, log=log)
+
+    def get(self, keyWord, default=None):
+        if keyWord == "SITE_NOREPLY_EMAIL":
+            val = self._noreply
+        elif keyWord == "SITE_MAILSERVER":
+            val = self._server
+        else:  # pragma: no cover
+            # sys.stderr.write("XXXXX Unknown site config fetching %s\n" % keyWord)
+            val = super(MyConfigInfo, self).get(keyWord=keyWord, default=default)
+
+        return val
+
+
+class StandardConfig(MyConfigInfo):
+     def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+         super(StandardConfig, self).__init__(siteId=siteId, verbose=verbose, log=log)
+
+
+class TestConfig(MyConfigInfo):
+     def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+         super(TestConfig, self).__init__(siteId=siteId, verbose=verbose, log=log)
+         self._noreply = "noreply@test.com"
+         self._server = "relayhost.test.com"
+
+
+class ConfigInfoAppCommunicationTests(unittest.TestCase):
+    @staticmethod
+    def testInstantiate():
+        """Test if instantiation of EM class works"""
+        ConfigInfoAppCommunication()
+
+
+    def testDefaultValues(self):
+        """Test default values"""
+        with patch("wwpdb.utils.config.ConfigInfoApp.ConfigInfo", side_effect=StandardConfig) as _mock_method:  # noqa: F841
+            ciac = ConfigInfoAppCommunication()
+            nr = ciac.get_noreply_address()
+            self.assertEqual(nr, "noreply@mail.wwpdb.org")
+
+            msa = ciac.get_mailserver_address()
+            self.assertEqual(msa, "localhost")
+
+    def testAlteredValues(self):
+        """Test override values"""
+        with patch("wwpdb.utils.config.ConfigInfoApp.ConfigInfo", side_effect=TestConfig) as _mock_method:  # noqa: F841
+            ciac = ConfigInfoAppCommunication()
+            nr = ciac.get_noreply_address()
+            self.assertEqual(nr, "noreply@test.com")
+
+            msa = ciac.get_mailserver_address()
+            self.assertEqual(msa, "relayhost.test.com")
+            
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/wwpdb/utils/tests-config/ConfigInfoAppDepuiTests.py
+++ b/wwpdb/utils/tests-config/ConfigInfoAppDepuiTests.py
@@ -23,7 +23,7 @@ import sys
 
 try:
     from unittest.mock import patch
-except ImportError:
+except ImportError:  # pragma: no cover
     from mock import patch
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -117,10 +117,10 @@ class ConfigInfoAppDepUITests(unittest.TestCase):
 
             # RW path to avoid fallbacks tests for destination file
             rwpath = os.path.join(TESTOUTPUT, "depuirw", "depui")
-            if not os.path.exists(rwpath):
+            if not os.path.exists(rwpath):  # pragma: no cover
                 os.makedirs(rwpath)
             testOutPath = os.path.join(rwpath, "site_dataset_siteloc_info.json")
-            if not os.path.exists(testOutPath):
+            if not os.path.exists(testOutPath):  # pragma: no cover
                 with open(testOutPath, "w") as _fout:  # noqa: F841
                     pass
 
@@ -130,5 +130,5 @@ class ConfigInfoAppDepUITests(unittest.TestCase):
                 self.assertEqual(slPath, testOutPath)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/wwpdb/utils/tests-config/ConfigInfoAppTests.py
+++ b/wwpdb/utils/tests-config/ConfigInfoAppTests.py
@@ -23,7 +23,7 @@ import sys
 
 try:
     from unittest.mock import patch
-except ImportError:
+except ImportError:  # pragma: no cover
     from mock import patch
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -127,5 +127,5 @@ class ConfigInfoAppComonTests(unittest.TestCase):
         self.assertNotIn("packages/", ipath)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/wwpdb/utils/tests-config/ConfigInfoTests.py
+++ b/wwpdb/utils/tests-config/ConfigInfoTests.py
@@ -97,5 +97,5 @@ class ConfigInfoFileTests(unittest.TestCase):
         self.assertEqual(time_t.isoweekday(), 5)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/wwpdb/utils/tests-config/ProjectInfoTests.py
+++ b/wwpdb/utils/tests-config/ProjectInfoTests.py
@@ -18,7 +18,7 @@ import logging
 
 try:
     from unittest.mock import patch
-except ImportError:
+except ImportError:  # pragma: no cover
     from mock import patch
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -80,12 +80,30 @@ class ProjectInfoTests(unittest.TestCase):
         self.assertEqual(vers, "unknown")
         self.assertTrue(mock_pvi.called)
 
+    def testGetVersionUnparseable(self):
+        """Test case -  get project version - json file unparseable"""
+        bad_file = os.path.join(TESTOUTPUT, "badversion.json")
+        with open(bad_file, "w") as fout:
+            fout.write('{"Version": "V5.14\n')
+
+        with patch.object(ProjectVersionInfo, "getVersionFile", return_value=bad_file) as mock_pvi:
+            # Disable logging to prevent reporting traceback from json parser
+            logging.disable(logging.ERROR)
+
+            pvi = ProjectVersionInfo()
+            vers = pvi.getVersion()
+            logging.disable(logging.NOTSET)
+            
+            self.assertEqual(vers, "unknown")
+            self.assertTrue(mock_pvi.called)
+            
 
 def suiteProjectVersion():  # pragma: no cover
     suiteSelect = unittest.TestSuite()
     suiteSelect.addTest(ProjectInfoTests("testGetVersion"))
     suiteSelect.addTest(ProjectInfoTests("testGetVersionFile"))
     suiteSelect.addTest(ProjectInfoTests("testGetVersionMissing"))
+    suiteSelect.addTest(ProjectInfoTests("testGetVersionUnparseable"))
     return suiteSelect
 
 


### PR DESCRIPTION
Allows one to specify a mail relay host and no-reply address - or provides defaults.
