### PR TITLE
DAOTHER-8060: Add support for ConfigInfoAppCommunication

### DIFF
--- a/wwpdb/utils/config/ConfigInfoApp.py
+++ b/wwpdb/utils/config/ConfigInfoApp.py
@@ -536,3 +536,24 @@ class ConfigInfoAppValidation(ConfigInfoAppBase):
 
     def get_density_fitness(self):
         return os.path.join(self.get_site_packages_path(), "density_fitness", "bin", "density-fitness")
+
+
+class ConfigInfoAppCommunication(ConfigInfoAppBase):
+    """Access configuration for sending email"""
+    def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+        super(ConfigInfoAppCommunication, self).__init__(siteId=siteId, verbose=verbose, log=log)
+
+    def get_noreply_address(self):
+        """Returns the noreply email address"""
+        
+        noreply_email = self._cI.get("SITE_NOREPLY_EMAIL",
+                                     "noreply@mail.wwpdb.org")
+
+        return noreply_email
+
+    def get_mailserver_address(self):
+        """Returns the sendmail local server or relay host"""
+        
+        return self._cI.get("SITE_MAILSERVER", "localhost")
+
+    

--- a/wwpdb/utils/config/ConfigInfoApp.py
+++ b/wwpdb/utils/config/ConfigInfoApp.py
@@ -551,9 +551,9 @@ class ConfigInfoAppCommunication(ConfigInfoAppBase):
 
         return noreply_email
 
-    def get_mailserver_address(self):
+    def get_mailserver_name(self):
         """Returns the sendmail local server or relay host"""
         
-        return self._cI.get("SITE_MAILSERVER", "localhost")
+        return self._cI.get("SITE_MAILSERVER_NAME", "localhost")
 
     

--- a/wwpdb/utils/tests-config/ConfigInfoAppCommunicationTests.py
+++ b/wwpdb/utils/tests-config/ConfigInfoAppCommunicationTests.py
@@ -61,7 +61,7 @@ class MyConfigInfo(ConfigInfo):
     def get(self, keyWord, default=None):
         if keyWord == "SITE_NOREPLY_EMAIL":
             val = self._noreply
-        elif keyWord == "SITE_MAILSERVER":
+        elif keyWord == "SITE_MAILSERVER_NAME":
             val = self._server
         else:  # pragma: no cover
             # sys.stderr.write("XXXXX Unknown site config fetching %s\n" % keyWord)
@@ -96,7 +96,7 @@ class ConfigInfoAppCommunicationTests(unittest.TestCase):
             nr = ciac.get_noreply_address()
             self.assertEqual(nr, "noreply@mail.wwpdb.org")
 
-            msa = ciac.get_mailserver_address()
+            msa = ciac.get_mailserver_name()
             self.assertEqual(msa, "localhost")
 
     def testAlteredValues(self):
@@ -106,7 +106,7 @@ class ConfigInfoAppCommunicationTests(unittest.TestCase):
             nr = ciac.get_noreply_address()
             self.assertEqual(nr, "noreply@test.com")
 
-            msa = ciac.get_mailserver_address()
+            msa = ciac.get_mailserver_name()
             self.assertEqual(msa, "relayhost.test.com")
             
 if __name__ == "__main__":  # pragma: no cover

--- a/wwpdb/utils/tests-config/ConfigInfoAppCommunicationTests.py
+++ b/wwpdb/utils/tests-config/ConfigInfoAppCommunicationTests.py
@@ -1,0 +1,113 @@
+#
+#
+# File:    ConfigInfoAppCommunicationTests.py
+# Author:  E. Peisach
+# Date:    18-Oct-2020
+# Version: 0.001
+##
+"""
+Test cases for communication settings
+"""
+
+__docformat__ = "restructuredtext en"
+__author__ = "Ezra Peisach"
+__email__ = "peisach@rcsb.rutgers.edu"
+__license__ = "Creative Commons Attribution 3.0 Unported"
+__version__ = "V0.01"
+
+import os
+import platform
+import unittest
+import warnings
+import sys
+
+try:
+    from unittest.mock import patch
+except ImportError:  # pragma: no cover
+    from mock import patch
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+TOPDIR = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+TESTOUTPUT = os.path.join(HERE, "test-output", platform.python_version())
+if not os.path.exists(TESTOUTPUT):  # pragma: no cover
+    os.makedirs(TESTOUTPUT)
+mockTopPath = os.path.join(TOPDIR, "wwpdb", "mock-data")
+rwMockTopPath = os.path.join(TESTOUTPUT)
+
+# Must create config file before importing ConfigInfo
+from wwpdb.utils.testing.SiteConfigSetup import SiteConfigSetup  # noqa: E402
+from wwpdb.utils.testing.CreateRWTree import CreateRWTree  # noqa: E402
+
+# Copy site-config and selected items
+crw = CreateRWTree(mockTopPath, TESTOUTPUT)
+crw.createtree(["site-config", "depuiresources", "webapps"])
+# Use populate r/w site-config using top mock site-config
+SiteConfigSetup().setupEnvironment(rwMockTopPath, rwMockTopPath)
+
+from wwpdb.utils.config.ConfigInfoApp import ConfigInfoAppCommunication  # noqa: E402
+from wwpdb.utils.config.ConfigInfo import ConfigInfo  # noqa: E402
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+TOPDIR = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+
+
+class MyConfigInfo(ConfigInfo):
+    """A class to setup tests for DepUI config"""
+    def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+        self._noreply = "noreply@mail.wwpdb.org"
+        self._server = "localhost"
+        super(MyConfigInfo, self).__init__(siteId=siteId, verbose=verbose, log=log)
+
+    def get(self, keyWord, default=None):
+        if keyWord == "SITE_NOREPLY_EMAIL":
+            val = self._noreply
+        elif keyWord == "SITE_MAILSERVER":
+            val = self._server
+        else:  # pragma: no cover
+            # sys.stderr.write("XXXXX Unknown site config fetching %s\n" % keyWord)
+            val = super(MyConfigInfo, self).get(keyWord=keyWord, default=default)
+
+        return val
+
+
+class StandardConfig(MyConfigInfo):
+     def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+         super(StandardConfig, self).__init__(siteId=siteId, verbose=verbose, log=log)
+
+
+class TestConfig(MyConfigInfo):
+     def __init__(self, siteId=None, verbose=True, log=sys.stderr):
+         super(TestConfig, self).__init__(siteId=siteId, verbose=verbose, log=log)
+         self._noreply = "noreply@test.com"
+         self._server = "relayhost.test.com"
+
+
+class ConfigInfoAppCommunicationTests(unittest.TestCase):
+    @staticmethod
+    def testInstantiate():
+        """Test if instantiation of EM class works"""
+        ConfigInfoAppCommunication()
+
+
+    def testDefaultValues(self):
+        """Test default values"""
+        with patch("wwpdb.utils.config.ConfigInfoApp.ConfigInfo", side_effect=StandardConfig) as _mock_method:  # noqa: F841
+            ciac = ConfigInfoAppCommunication()
+            nr = ciac.get_noreply_address()
+            self.assertEqual(nr, "noreply@mail.wwpdb.org")
+
+            msa = ciac.get_mailserver_address()
+            self.assertEqual(msa, "localhost")
+
+    def testAlteredValues(self):
+        """Test override values"""
+        with patch("wwpdb.utils.config.ConfigInfoApp.ConfigInfo", side_effect=TestConfig) as _mock_method:  # noqa: F841
+            ciac = ConfigInfoAppCommunication()
+            nr = ciac.get_noreply_address()
+            self.assertEqual(nr, "noreply@test.com")
+
+            msa = ciac.get_mailserver_address()
+            self.assertEqual(msa, "relayhost.test.com")
+            
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Allows one to specify a mail relay host and no-reply address - or provides defaults.