### PR TITLE
Add support for 'deposit-to-archive-wfcfg' content type in config

### DIFF
--- a/wwpdb/utils/config/ConfigInfoData.py
+++ b/wwpdb/utils/config/ConfigInfoData.py
@@ -419,6 +419,7 @@ class ConfigInfoData:
         "manifest-session": (["json"], "manifest-session"),
         "manifest-session-bundle": (["json"], "manifest-session-bundle"),
         "pcm-missing-data": (["csv"], "pcm-missing-data"),
+        "deposit-to-archive-wfcfg": (["json"], "deposit-to-archive-wfcfg"),
         "any": (["any"], "any"),
     }  # type: Dict[str, Tuple[List[str], str]]
     """Base dictionary of supported file formats for each recognized content type.


### PR DESCRIPTION
### Description

This PR adds support for the `'deposit-to-archive-wfcfg'` content type in the configuration system.

This update is part of the ongoing EBI infrastructure adjustments, where a new workflow is being introduced to handle file transfers from `deposit` to `archive` directories. By supporting the `'deposit-to-archive-wfcfg'` content type, the configuration module can now recognize and manage settings specific to this new workflow, ensuring seamless integration with the updated file management processes.

Key improvements:
- Adds recognition and handling of the `'deposit-to-archive-wfcfg'` content type.
- Enables configuration-driven support for the new deposit-to-archive file transfer workflow.
- Facilitates infrastructure changes where DepUI will no longer have direct write access to the archive location.

These changes help ensure that configuration management remains robust and adaptable as the EBI infrastructure evolves.